### PR TITLE
Link added to the badge #8

### DIFF
--- a/ReadME.md
+++ b/ReadME.md
@@ -1,5 +1,5 @@
 # A Bunch of Shade
-![badge](https://img.shields.io/badge/Made%20with%20%E2%99%A5%20by%20-Jessica%20E.%20Calderon-blueviolet)
+[![badge](https://img.shields.io/badge/Made%20with%20%E2%99%A5%20by%20-Jessica%20E.%20Calderon-blueviolet)](https://github.com/jessica-calderon)
 ## Table of Contents
 * [Description](#description)
 * [Built With](#languages)


### PR DESCRIPTION
Now the badge has clickable link to the GitHub profile.

Before : 
![Screenshot 2022-09-20 at 12-36-01 New Issue · jessica-calderon_abunchofshade](https://user-images.githubusercontent.com/110970889/191191608-119181f1-a58f-45ff-a25b-b7dbfdbb2848.png)

After :
![Screenshot 2022-09-20 at 12-44-00 Comparing jessica-calderon main realrohitgurav patch-1 · jessica-calderon_abunchofshade](https://user-images.githubusercontent.com/110970889/191191670-cf0a5e7a-0f1f-4a1d-9c50-093bbbfe5f4a.png)
